### PR TITLE
Added some more advanced examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ This format specification represents the consensus for the standard representati
 ## Use cases supported (with examples)
 The ProForma notation is a string of characters that represent linearly one or more peptidoform/proteoform primary structures with possibilities to link peptidic chains together. It is not meant to represent secondary or tertiary structures. 
 
-##### Canonical [IUPAC amino acids](http://publications.iupac.org/pac/1984/pdf/5605x0595.pdf)
+##### Canonical [IUPAC amino acids](http://publications.iupac.org/pac/1984/pdf/5605x0595.pdf) and [ambiguous/unusual amino acids](https://www.insdc.org/submitting-standards/feature-table/#7.4.3)
 * `EMEVEESPEK`
+* `VAEJNPSNGGTT` (J indicates either I or L)
 ##### PTMs using common ontologies or controlled vocabularies (e.g. [Unimod](http://www.unimod.org/), [PSI-MOD](https://www.ebi.ac.uk/ols/ontologies/mod), and [RESID](https://proteininformationresource.org/resid/))
 * `EM[Oxidation]EVEES[UNIMOD:21]PEK`
 * `EM[L-methionine sulfoxide]EVEES[MOD:00046]PEK`
@@ -39,3 +40,9 @@ The ProForma notation is a string of characters that represent linearly one or m
 ##### Additional user-supplied information and multi-valued tags
 * `ELV[info:AnyString]IS`
 * `ELV[+11.9784|info:suspected frobinylation]IS`
+##### Defined charges, or charge cariers (ProForma extension see section 7.1)
+* `VAEINPSNGGTT/2`
+* `VAEINPSNGGTT/2[1Na+,1H+]`
+##### Chimeric spectra (ProForma extension see section 7.2)
+* `VAEINPSNGGTT+FNEKFKGGKATJ`
+* `[iTRAQ4plex]-EMEVNESPEK-[Methyl]+[Phospho]?EMEVTSESPEK`


### PR DESCRIPTION
I do not know if you agree on there being a need for these more advanced use cases to be included. On my example sheets I have always included them, because especially the chimeric peptides case is quite common for us to find (in TD). My software is one where you can manually annotate a peptide using ProForma and the chimeric case is very handy to know about it that case. If these where to be merged I could remove my own examples and instead link through to these ones.

_Sidenote:_ the link in the final spec document to unusual AAs (section 4.1) is broken. It should link to 7.4.3 instead of 7.5.3 (I put the correct link in the example here as well).